### PR TITLE
Added inheritance of required_element_list from parent region

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-
+  gem 'ruby-debug-ide', group: :development
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    rake (12.0.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -38,6 +39,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    ruby-debug-ide (0.6.0)
+      rake (>= 0.8.1)
     rubyzip (1.2.1)
     selenium-webdriver (3.1.0)
       childprocess (~> 0.5)
@@ -65,6 +68,7 @@ DEPENDENCIES
   ferris_watir!
   pry
   rspec (~> 3.0)
+  ruby-debug-ide
 
 BUNDLED WITH
-   1.14.3
+   1.14.6

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -2,6 +2,6 @@
   "RSpec": {
     "coverage": {
     },
-    "timestamp": 1487859620
+    "timestamp": 1491316580
   }
 }

--- a/spec/ferris_spec.rb
+++ b/spec/ferris_spec.rb
@@ -29,4 +29,33 @@ describe 'Wikipedia' do
   it 'can throw a .present? exception' do
     expect { home_page.present? }.to raise_error(Ferris::RootMissingException)
   end
+
+  context "Page inheritance" do
+    it 'Child page includes required elements of his ancestors' do
+      expected = [:grand_req, :parent_req, :child_req]
+      expect(TestSite::Child.required_element_list).to match(expected)
+    end
+
+    it 'Parent page includes required elements of grandparent' do
+      expected = [:grand_req, :parent_req]
+      expect(TestSite::Parent.required_element_list).to match(expected)
+    end
+
+    it 'Page includes its required elements' do
+      expect(TestSite::Grandparent.required_element_list).to match([:grand_req])
+    end
+
+    it 'Page does not include required elements of its heirs' do
+      expect(TestSite::Grandparent.required_element_list).not_to include(:parent_req)
+      expect(TestSite::Grandparent.required_element_list).not_to include(:child_req)
+    end
+
+    it 'Child page waits for all ancestors required elements to load' do
+      expect_any_instance_of(TestSite::Child).to receive_message_chain(:grand_req, :present?) { true }
+      expect_any_instance_of(TestSite::Child).to receive_message_chain(:parent_req, :present?) { true }
+      expect_any_instance_of(TestSite::Child).to receive_message_chain(:child_req, :present?) { true }
+
+      expect(child_page.visit.loaded?).to be_truthy
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
-require_relative '../lib/ferris'
-require_relative 'support/site'
+require './spec/support/site'
 require 'coveralls'
 
 Coveralls.wear!

--- a/spec/support/pages/apple.rb
+++ b/spec/support/pages/apple.rb
@@ -1,9 +1,8 @@
-module Pages
+module TestSite
   class Apple < Ferris::Core
     partial_url(required: true) { '/wiki/Apple' }
     page_title(required: true) { 'Apple - Wikipedia' }
 
     element(:article_heading, required: true) { browser.h1(id: 'firstHeading') }
-
   end
 end

--- a/spec/support/pages/child.rb
+++ b/spec/support/pages/child.rb
@@ -1,0 +1,6 @@
+module TestSite
+  class Child < Parent
+    partial_url { '/child' }
+    element(:child_req, required: true)  { browser.div(id: 'child_id') }
+  end
+end

--- a/spec/support/pages/grandparent.rb
+++ b/spec/support/pages/grandparent.rb
@@ -1,0 +1,6 @@
+module TestSite
+  class Grandparent < Ferris::Core
+    partial_url { '/grandparent' }
+    element(:grand_req, required: true)  { browser.div(id: 'grand_id') }
+  end
+end

--- a/spec/support/pages/home.rb
+++ b/spec/support/pages/home.rb
@@ -1,4 +1,4 @@
-module Pages
+module TestSite
   class Home < Ferris::Core
     partial_url { '/wiki/Main_Page' }
   end

--- a/spec/support/pages/parent.rb
+++ b/spec/support/pages/parent.rb
@@ -1,0 +1,6 @@
+module TestSite
+  class Parent < Grandparent
+    partial_url { '/parent' }
+    element(:parent_req, required: true)  { browser.div(id: 'parent_id') }
+  end
+end

--- a/spec/support/regions/header.rb
+++ b/spec/support/regions/header.rb
@@ -1,4 +1,4 @@
-module Regions
+module TestSite
   class Header < Ferris::Core
     element(:search_term) { root.text_field(id: 'searchInput') }
     element(:submit_btn)  { root.button(name: 'go') }

--- a/spec/support/site.rb
+++ b/spec/support/site.rb
@@ -1,17 +1,25 @@
-require_relative 'pages/home'
-require_relative 'pages/apple'
-require_relative 'regions/header'
+require './lib/ferris'
+
+require './spec/support/regions/header'
+
+require './spec/support/pages/home'
+require './spec/support/pages/apple'
+require './spec/support/pages/grandparent'
+require './spec/support/pages/parent'
+require './spec/support/pages/child'
 
 module Ferris
   module SiteObject
     class Wikipedia
       SiteObject.configure do
         base_url('https://en.wikipedia.org')
+        page(:home_page, TestSite::Home)
+        page(:apple_page, TestSite::Apple)
+        page(:child_page, TestSite::Child)
+        page(:parent_page, TestSite::Parent)
+        page(:grandparent_page, TestSite::Grandparent)
 
-        page(:home_page, Pages::Home)
-        page(:apple_page, Pages::Apple)
-
-        region(:header, Regions::Header) { browser.div(id: 'mw-head') }
+        region(:header, TestSite::Header) { browser.div(id: 'mw-head') }
       end
     end
   end


### PR DESCRIPTION
When inherit page from another page, calling `.loaded?` on child will check whether the required elements of it's parent (and all it's ancestors if any) are present. 

```
  class Grandparent < Ferris::Core
    element(:grand_req, required: true)  { browser.div(id: 'grand_id') }
  end

  class Parent < Grandparent
    element(:parent_req, required: true)  { browser.div(id: 'parent_id') }
  end

  class Child < Parent
    element(:child_req, required: true)  { browser.div(id: 'child_id') }
  end
```

`Grandparent.new.loaded?` will only wait for it's own required elements to load.
`Parent.new.loaded?` will wait for it's own as well as `Grandparent's` required elements.
`Child.new.loaded?` will wait for it's own, `Parent's` and `Grandparent's`.
